### PR TITLE
Fix typo in recipe-sherlock-gpu.md

### DIFF
--- a/examples/recipe-sherlock-gpu.md
+++ b/examples/recipe-sherlock-gpu.md
@@ -55,7 +55,7 @@ module load nccl
 ### 6. now, open ipython, run
 ```python
 import torch
-print(torch.cuda.is_avilable())
+print(torch.cuda.is_available())
 ```
 if print out is `True`, then you'er OK to use GPUs.
 


### PR DESCRIPTION
Fix typo in code: `is_avilable()` → `is_available()`.