### PR TITLE
Making updates to sbatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ If you would like to request a custom notebook, please [reach out](https://www.g
 # To start a jupyter notebook in a specific directory ON the cluster resource
 bash start.sh jupyter <cluster-dir>
 
-# If you don't specify a path on the cluster, it defaults to your ${SCRATCH}
-bash start.sh jupyter /scratch/users/<username>
+# If you don't specify a path on the cluster, it defaults to your ${HOME}
+bash start.sh jupyter /home/users/<username>
 
 # To start a jupyter notebook with tensorflow in a specific directory
 bash start.sh py2-tensorflow <cluster-dir>

--- a/sbatches/sherlock/containershare-notebook.sbatch
+++ b/sbatches/sherlock/containershare-notebook.sbatch
@@ -47,6 +47,7 @@ CONTAINER="${2}"
 NOTEBOOK_DIR="${3:-${SCRATCH}}"
 CONTAINERSHARE=${4:-/scratch/users/vsochat/share}
 
+source /etc/bashrc
 module use system
 module load singularity
 export SINGULARITY_CACHEDIR="${SCRATCH}/.singularity"

--- a/sbatches/sherlock/jupyter-gpu.sbatch
+++ b/sbatches/sherlock/jupyter-gpu.sbatch
@@ -8,6 +8,8 @@ else
     cd $NOTEBOOK_DIR
 fi
 
+source /etc/bashrc
+
 ## to compile libtorch C++ code, load these modules
 # module load gcc/7.3.0
 # module load gdb

--- a/sbatches/sherlock/jupyter.sbatch
+++ b/sbatches/sherlock/jupyter.sbatch
@@ -4,5 +4,6 @@ PORT=$1
 NOTEBOOK_DIR=$2
 cd $NOTEBOOK_DIR
 
+source /etc/bashrc
 module load py-jupyter/1.0.0_py27
 jupyter notebook --no-browser --port=$PORT

--- a/sbatches/sherlock/py2-jupyter.sbatch
+++ b/sbatches/sherlock/py2-jupyter.sbatch
@@ -4,5 +4,6 @@ PORT=$1
 NOTEBOOK_DIR=$2
 cd $NOTEBOOK_DIR
 
+source /etc/bashrc
 module load py-jupyter/1.0.0_py27
 jupyter notebook --no-browser --port=$PORT

--- a/sbatches/sherlock/py2-tensorflow.sbatch
+++ b/sbatches/sherlock/py2-tensorflow.sbatch
@@ -3,6 +3,7 @@ PORT=$1
 NOTEBOOK_DIR=$2
 cd $NOTEBOOK_DIR
 
+source /etc/bashrc
 module load protobuf/3.4.0
 module load py-jupyter/1.0.0_py27
 module load py-tensorflow/1.8.0_py27

--- a/sbatches/sherlock/py3-jupyter.sbatch
+++ b/sbatches/sherlock/py3-jupyter.sbatch
@@ -4,5 +4,6 @@ PORT=$1
 NOTEBOOK_DIR=${2:-${SCRATCH}}
 cd $NOTEBOOK_DIR
 
+source /etc/bashrc
 module load py-jupyter/1.0.0_py36
 jupyter notebook --no-browser --port=$PORT

--- a/sbatches/sherlock/py3-tensorflow.sbatch
+++ b/sbatches/sherlock/py3-tensorflow.sbatch
@@ -4,6 +4,7 @@ PORT=$1
 NOTEBOOK_DIR=$2
 cd $NOTEBOOK_DIR
 
+source /etc/bashrc
 module load py-jupyter/1.0.0_py36
 module load py-tensorflow/1.9.0_py36
 

--- a/sbatches/sherlock/r-jupyter.sbatch
+++ b/sbatches/sherlock/r-jupyter.sbatch
@@ -4,6 +4,7 @@ PORT=$1
 NOTEBOOK_DIR=$2
 cd $NOTEBOOK_DIR
 
+source /etc/bashrc
 module load py-jupyter/1.0.0_py36
 module load R/3.5.1
 

--- a/sbatches/sherlock/r3.4-jupyter.sbatch
+++ b/sbatches/sherlock/r3.4-jupyter.sbatch
@@ -4,6 +4,7 @@ PORT=$1
 NOTEBOOK_DIR=$2
 cd $NOTEBOOK_DIR
 
+source /etc/bashrc
 module load py-jupyter/1.0.0_py36
 module load R/3.4.0
 

--- a/sbatches/sherlock/singularity-exec.sbatch
+++ b/sbatches/sherlock/singularity-exec.sbatch
@@ -16,6 +16,7 @@ fi
 
 cd $NOTEBOOK_DIR
 
+source /etc/bashrc
 module use system
 module load singularity
 export SINGULARITY_CACHEDIR=$SCRATCH/.singularity

--- a/sbatches/sherlock/singularity-notebook.sbatch
+++ b/sbatches/sherlock/singularity-notebook.sbatch
@@ -37,6 +37,7 @@ PORT=$1
 CONTAINER="${2}"
 NOTEBOOK_DIR="${3:-${SCRATCH}}"
 
+source /etc/bashrc
 module use system
 module load singularity
 export SINGULARITY_CACHEDIR="${SCRATCH}/.singularity"

--- a/sbatches/sherlock/singularity-run.sbatch
+++ b/sbatches/sherlock/singularity-run.sbatch
@@ -16,6 +16,7 @@ fi
 
 cd $NOTEBOOK_DIR
 
+source /etc/bashrc
 module use system
 module load singularity
 export SINGULARITY_CACHEDIR=$SCRATCH/.singularity

--- a/sbatches/sherlock/tensorboard.sbatch
+++ b/sbatches/sherlock/tensorboard.sbatch
@@ -2,5 +2,6 @@
 PORT=$1
 TENSORBOARD_DIR=$2
 
+source /etc/bashrc
 module load py-tensorflow/1.8.0_py27
 python -m tensorboard.main --logdir $TENSORBOARD_DIR --debug --port=$PORT

--- a/start.sh
+++ b/start.sh
@@ -82,9 +82,18 @@ print_logs
 echo
 instruction_get_logs
 
-echo 
-echo "== Instructions =="
-echo "1. Password, output, and error printed to this terminal? Look at logs (see instruction above)"
-echo "2. Browser: http://$MACHINE:$PORT/ -> http://localhost:$PORT/..."
-echo "3. To end session: bash end.sh ${NAME}"
+if [ $NAME = "jupyter" ]
+then
+  echo
+  echo "== Instructions =="
+  echo "1. Obtain connection URL from jupyter.sbatch.err (see instruction above)"
+  echo "2. Enter URL in browser: http://localhost:$PORT/?token=..."
+  echo "3. To end session: bash end.sh ${NAME}"
+else
+  echo 
+  echo "== Instructions =="
+  echo "1. Password, output, and error printed to this terminal? Look at logs (see instruction above)"
+  echo "2. Browser: http://$MACHINE:$PORT/ -> http://localhost:$PORT/..."
+  echo "3. To end session: bash end.sh ${NAME}"
+fi
 


### PR DESCRIPTION
It seems non-interactive ssh to Sherlock requires running `source /etc/bashrc` in order to use module commands. I added this to all of the sbatch scripts that use `module ...`.

I also added specific instructions to `start.sh` for connecting to a Jupyter notebook based on some confusion a Sherlock user had locating the URL.